### PR TITLE
Fix broken build and modernize repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,48 +3,33 @@ name: Update README
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '47 1 * * *'
+    - cron: '47 1 * * *'
   push:
     branches:
       - master
+
+permissions:
+  contents: write
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '14'
-      - name: Fetch SDKMan
-        run: curl -s https://get.sdkman.io -o install-sdkman
-      - name: Install SDKMan
-        run: |
-          chmod u+x install-sdkman
-          ./install-sdkman
-          echo "SDKMAN_DIR=$HOME/.sdkman" >> $GITHUB_ENV
-      - name: Install Kotlin Scripting
-        run: |
-          . $SDKMAN_DIR/bin/sdkman-init.sh
-          sdk install kotlin
-          echo "PATH=$PATH:$SDKMAN_DIR/candidates/kotlin/current/bin" >> $GITHUB_ENV
-      - name: Get current time
-        uses: gerred/actions/current-time@master
-        id: current-time
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Install Kotlin
+        run: sudo snap install --classic kotlin
       - name: Update README
-        env:
-          TIMESTAMP      : ${{ steps.current-time.outputs.time }}
         run: ./update.main.kts
-      - name: Commit README to repo
+      - name: Commit and push changes
         run: |
           git config --local user.email "action@kotov.lv"
           git config --local user.name  "GitHub Action"
-          git add .
-          git status
+          git add README.adoc
           git diff-index --quiet HEAD || git commit -m "Automatically update README.adoc"
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git push

--- a/template.adoc
+++ b/template.adoc
@@ -4,7 +4,7 @@
 |===
 <#list posts as post>
 
-| ${(post.published).format('MMMM d, YYYY')}
+| ${(post.published).format('MMMM d, yyyy')}
 | ${post.link}[${post.title}^]
 </#list>
 |===

--- a/update.main.kts
+++ b/update.main.kts
@@ -1,28 +1,18 @@
 #!/usr/bin/env kotlin
 
-@file:Repository("https://jcenter.bintray.com")
-@file:DependsOn("org.freemarker:freemarker:2.3.30")
-@file:DependsOn("com.squareup.okhttp3:okhttp:4.8.0")
-@file:DependsOn("no.api.freemarker:freemarker-java8:2.0.0")
-@file:DependsOn("org.yaml:snakeyaml:1.26")
-@file:DependsOn("org.apache.commons:commons-text:1.9")
-@file:DependsOn("org.json:json:20200518")
-@file:DependsOn("org.jsoup:jsoup:1.13.1")
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:DependsOn("org.freemarker:freemarker:2.3.34")
+@file:DependsOn("com.squareup.okhttp3:okhttp:4.12.0")
+@file:DependsOn("no.api.freemarker:freemarker-java8:2.1.0")
 
 
 import freemarker.template.*
 import no.api.freemarker.java8.Java8ObjectWrapper
 import okhttp3.*
-import org.apache.commons.text.StringEscapeUtils
-import org.apache.commons.text.similarity.JaroWinklerSimilarity
-import org.json.JSONObject
-import org.jsoup.Jsoup
-import org.w3c.dom.Element
 import org.w3c.dom.NodeList
-import org.yaml.snakeyaml.Yaml
 import java.io.*
 import java.time.LocalDate
-import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.xml.parsers.DocumentBuilderFactory
@@ -32,14 +22,16 @@ import javax.xml.xpath.XPathFactory
 val client = OkHttpClient()
 
 fun <T> execute(builder: Request.Builder, extractor: (String?) -> T): T {
-    val body = client.newCall(builder.build())
-        .execute()
-        .body
-        ?.string()
-    return extractor(body)
+    client.newCall(builder.build()).execute().use { response ->
+        if (!response.isSuccessful) {
+            throw RuntimeException("HTTP ${response.code}: ${response.message}")
+        }
+        val body = response.body?.string()
+        return extractor(body)
+    }
 }
 
-val template = Configuration(Configuration.VERSION_2_3_29)
+val template = Configuration(Configuration.VERSION_2_3_34)
     .apply {
         setDirectoryForTemplateLoading(File("."))
         defaultEncoding = "UTF-8"
@@ -50,28 +42,33 @@ val template = Configuration(Configuration.VERSION_2_3_29)
         objectWrapper = Java8ObjectWrapper(this.incompatibleImprovements)
     }.getTemplate("template.adoc")
 
+val MAX_POSTS = 6
+
 val posts: List<Post> by lazy {
     fun String.toLocalDate(): LocalDate {
         val formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US)
-        return LocalDate.parse(this, formatter)
+        return ZonedDateTime.parse(this.trim(), formatter).toLocalDate()
     }
 
-    fun NodeList.toPost() = Post(
-        item(5).textContent.toLocalDate(),
-        item(1).textContent,
-        item(7).textContent
-    )
+    fun org.w3c.dom.Node.toPost(): Post {
+        val xpath = XPathFactory.newInstance().newXPath()
+        val pubDate = xpath.evaluate("pubDate", this).trim().toLocalDate()
+        val title = xpath.evaluate("title", this).trim()
+        val link = xpath.evaluate("link", this).trim()
+        return Post(pubDate, title, link)
+    }
 
     val extractPosts = { body: String? ->
+        val bytes = body?.toByteArray(Charsets.UTF_8)
+            ?: throw RuntimeException("Empty response from RSS feed")
         val document = DocumentBuilderFactory
             .newInstance()
             .newDocumentBuilder()
-            .parse(ByteArrayInputStream(body?.toByteArray(Charsets.UTF_8)))
+            .parse(ByteArrayInputStream(bytes))
         val xpath = XPathFactory.newInstance().newXPath()
         val nodes = xpath.evaluate("/rss/channel/item", document, XPathConstants.NODESET) as NodeList
-        (0..5).map { nodes.item(it) }
-            .map { (it as Element).childNodes }
-            .map { it.toPost() }
+        val count = minOf(nodes.length, MAX_POSTS)
+        (0 until count).map { nodes.item(it).toPost() }
     }
 
     val request = Request.Builder()
@@ -85,6 +82,8 @@ val root = mapOf(
     "posts" to posts
 )
 
-template.process(root, FileWriter("README.adoc"))
+FileWriter("README.adoc").use { writer ->
+    template.process(root, writer)
+}
 
 data class Post(val published: LocalDate, val title: String, val link: String)


### PR DESCRIPTION
- Replace defunct JCenter repo with Maven Central
- Update dependencies (FreeMarker 2.3.34, OkHttp 4.12.0, freemarker-java8 2.1.0)
- Remove 4 unused dependencies (snakeyaml, commons-text, json, jsoup)
- Fix date parsing bug: use ZonedDateTime.parse instead of LocalDate.parse
- Fix fragile XPath child node indexing with proper XPath queries
- Add bounds check for RSS items to prevent crash on short feeds
- Fix resource leaks: close HTTP response and FileWriter
- Add HTTP error handling
- Modernize CI: actions/checkout@v4, setup-java@v4, Java 21 LTS
- Remove unpinned third-party actions (gerred/current-time, ad-m/github-push-action)
- Replace SDKMan with snap install for Kotlin
- Fix template date format (YYYY → yyyy) to prevent week-year bug

https://claude.ai/code/session_0123RDfe9cpC3U3EqwmDYDAa