### PR TITLE
Refactor README generation script for clarity and idiomatic Kotlin

### DIFF
--- a/update.main.kts
+++ b/update.main.kts
@@ -5,31 +5,70 @@
 @file:DependsOn("com.squareup.okhttp3:okhttp:4.12.0")
 @file:DependsOn("no.api.freemarker:freemarker-java8:2.1.0")
 
-
-import freemarker.template.*
+import freemarker.template.Configuration
+import freemarker.template.TemplateExceptionHandler
 import no.api.freemarker.java8.Java8ObjectWrapper
-import okhttp3.*
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.w3c.dom.Node
 import org.w3c.dom.NodeList
-import java.io.*
+import java.io.ByteArrayInputStream
+import java.io.File
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.Locale
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathFactory
 
-val client = OkHttpClient()
+data class Post(val published: LocalDate, val title: String, val link: String)
 
-fun <T> execute(builder: Request.Builder, extractor: (String?) -> T): T {
-    client.newCall(builder.build()).execute().use { response ->
+val FEED_URL = "https://blog.kotov.lv/feed.xml"
+val MAX_POSTS = 6
+
+// --- RSS parsing ---
+
+val RSS_DATE_FORMAT = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US)
+
+fun String.toLocalDate(): LocalDate =
+    ZonedDateTime.parse(trim(), RSS_DATE_FORMAT).toLocalDate()
+
+fun Node.toPost(): Post {
+    val xpath = XPathFactory.newInstance().newXPath()
+    return Post(
+        published = xpath.evaluate("pubDate", this).toLocalDate(),
+        title = xpath.evaluate("title", this).trim(),
+        link = xpath.evaluate("link", this).trim()
+    )
+}
+
+fun parsePosts(xml: String): List<Post> {
+    val document = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .parse(ByteArrayInputStream(xml.toByteArray()))
+    val nodes = XPathFactory.newInstance().newXPath()
+        .evaluate("/rss/channel/item", document, XPathConstants.NODESET) as NodeList
+    return (0 until minOf(nodes.length, MAX_POSTS)).map { nodes.item(it).toPost() }
+}
+
+// --- HTTP ---
+
+fun fetchFeed(): String {
+    val request = Request.Builder()
+        .url(FEED_URL)
+        .addHeader("User-Agent", "Mozilla/5.0")
+        .build()
+    OkHttpClient().newCall(request).execute().use { response ->
         if (!response.isSuccessful) {
             throw RuntimeException("HTTP ${response.code}: ${response.message}")
         }
-        val body = response.body?.string()
-        return extractor(body)
+        return response.body?.string()
+            ?: throw RuntimeException("Empty response from RSS feed")
     }
 }
+
+// --- Template ---
 
 val template = Configuration(Configuration.VERSION_2_3_34)
     .apply {
@@ -39,51 +78,13 @@ val template = Configuration(Configuration.VERSION_2_3_34)
         logTemplateExceptions = false
         wrapUncheckedExceptions = true
         fallbackOnNullLoopVariable = false
-        objectWrapper = Java8ObjectWrapper(this.incompatibleImprovements)
+        objectWrapper = Java8ObjectWrapper(incompatibleImprovements)
     }.getTemplate("template.adoc")
 
-val MAX_POSTS = 6
+// --- Main ---
 
-val posts: List<Post> by lazy {
-    fun String.toLocalDate(): LocalDate {
-        val formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US)
-        return ZonedDateTime.parse(this.trim(), formatter).toLocalDate()
-    }
+val posts = parsePosts(fetchFeed())
 
-    fun org.w3c.dom.Node.toPost(): Post {
-        val xpath = XPathFactory.newInstance().newXPath()
-        val pubDate = xpath.evaluate("pubDate", this).trim().toLocalDate()
-        val title = xpath.evaluate("title", this).trim()
-        val link = xpath.evaluate("link", this).trim()
-        return Post(pubDate, title, link)
-    }
-
-    val extractPosts = { body: String? ->
-        val bytes = body?.toByteArray(Charsets.UTF_8)
-            ?: throw RuntimeException("Empty response from RSS feed")
-        val document = DocumentBuilderFactory
-            .newInstance()
-            .newDocumentBuilder()
-            .parse(ByteArrayInputStream(bytes))
-        val xpath = XPathFactory.newInstance().newXPath()
-        val nodes = xpath.evaluate("/rss/channel/item", document, XPathConstants.NODESET) as NodeList
-        val count = minOf(nodes.length, MAX_POSTS)
-        (0 until count).map { nodes.item(it).toPost() }
-    }
-
-    val request = Request.Builder()
-        .url("https://blog.kotov.lv/feed.xml")
-        .addHeader("User-Agent", "Mozilla/5.0")
-
-    execute(request, extractPosts)
+File("README.adoc").writer().use { writer ->
+    template.process(mapOf("posts" to posts), writer)
 }
-
-val root = mapOf(
-    "posts" to posts
-)
-
-FileWriter("README.adoc").use { writer ->
-    template.process(root, writer)
-}
-
-data class Post(val published: LocalDate, val title: String, val link: String)


### PR DESCRIPTION
- Move Post data class to top (declaration before use)
- Extract nested functions from lazy block into standalone top-level functions
- Replace unnecessary lazy evaluation with direct linear execution
- Remove overly generic execute() helper in favor of focused fetchFeed()
- Extract feed URL as a named constant
- Hoist DateTimeFormatter to a top-level val (avoid recreation per call)
- Replace wildcard imports with specific imports
- Use named parameters for Post constructor
- Use File.writer() instead of FileWriter
- Eliminate intermediate root variable
- Organize script into clear sections: data, parsing, HTTP, template, main

https://claude.ai/code/session_01GxPcJGsUxFRoh2b8YXW97B